### PR TITLE
feat: add nested palette support with dot-notation access

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ meta {
 
 ### Palette Block
 
-Define your color constants as hex values. The names can be arbitrary.
+Define your color constants as hex values. The names can be arbitrary. Supports nested blocks for organizing colors hierarchically.
 
 ```hcl
 palette {
@@ -31,10 +31,29 @@ palette {
   text    = "#e0def4"
   love    = "#eb6f92"
   gold    = "#f6c177"
+
+  highlight {
+    low  = "#21202e"
+    mid  = "#403d52"
+    high = "#524f67"
+  }
 }
 ```
 
-Palette colors can be referenced by other blocks using `palette.<name>` syntax.
+Palette colors can be referenced by other blocks using `palette.<name>` syntax for direct colors, or `palette.<scope>.<name>` for nested colors.
+
+All palette values are accessible in templates using the `palette` function with dot-notation paths:
+
+```text
+{{ palette "highlight.low" | hex }}
+{{ palette "base" | hexBare }}
+```
+
+To access style flags (bold, italic, underline), use the `style` function:
+
+```text
+{{ if (style "custom.bold").Bold }}bold{{ end }}
+```
 
 ### Theme Block
 
@@ -104,7 +123,7 @@ Style properties (`bold`, `italic`, `underline`) are optional and default to fal
 Templates transform your theme data into application-specific config files. They live in the `templates/` directory and use Go's text/template syntax with these data structures:
 
 - `.Meta` - name, author, appearance
-- `.Palette` - raw color definitions
+- `.Palette` - color definitions as a nested tree (values are Style objects)
 - `.Theme` - UI color mappings
 - `.Syntax` - syntax highlighting rules with optional styles
 - `.ANSI` - terminal colors
@@ -112,7 +131,10 @@ Templates transform your theme data into application-specific config files. They
 ### Template Functions
 
 - `hex` - outputs color as quoted hex (e.g., `"#191724"`)
-- `hexBare` - outputs color as bare hex (e.g., `#191724`)
+- `hexBare` - outputs color as bare hex (e.g., `191724`)
+- `rgb` - outputs color as rgb() format (e.g., `rgb(25, 23, 36)`)
+- `palette` - returns a Color from the palette by dot-notation path (e.g., `palette "highlight.low"`)
+- `style` - returns a Style from the palette by dot-notation path (e.g., `style "custom.bold"`)
 
 ### Example Templates
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -21,7 +21,13 @@ type Style struct {
 
 // ColorTree represents a nested map of colors, used for syntax scopes.
 // Values are either Style or ColorTree.
-type ColorTree map[string]interface{}
+type ColorTree map[string]any
+
+// IsStyle returns true if the value is a Style (leaf node), false if it's a ColorTree.
+func IsStyle(v any) bool {
+	_, ok := v.(Style)
+	return ok
+}
 
 // ParseHex parses a hex color string like "#eb6f92" into a Color.
 func ParseHex(s string) (Color, error) {

--- a/theme.hcl
+++ b/theme.hcl
@@ -2,32 +2,36 @@ meta {
   name       = "Rosé Pine"
   author     = "Rosé Pine"
   appearance = "dark"
+  url        = "https://rosepinetheme.com"
 }
 
 palette {
-  base           = "#191724"
-  surface        = "#1f1d2e"
-  overlay        = "#26233a"
-  muted          = "#6e6a86"
-  subtle         = "#908caa"
-  text           = "#e0def4"
-  love           = "#eb6f92"
-  gold           = "#f6c177"
-  rose           = "#ebbcba"
-  pine           = "#31748f"
-  foam           = "#9ccfd8"
-  iris           = "#c4a7e7"
-  highlight_low  = "#21202e"
-  highlight_med  = "#403d52"
-  highlight_high = "#524f67"
+  base    = "#191724"
+  surface = "#1f1d2e"
+  overlay = "#26233a"
+  muted   = "#6e6a86"
+  subtle  = "#908caa"
+  text    = "#e0def4"
+  love    = "#eb6f92"
+  gold    = "#f6c177"
+  rose    = "#ebbcba"
+  pine    = "#31748f"
+  foam    = "#9ccfd8"
+  iris    = "#c4a7e7"
+
+  highlight {
+    low  = "#21202e"
+    mid  = "#403d52"
+    high = "#524f67"
+  }
 }
 
 theme {
   background        = palette.base
   foreground        = palette.text
-  cursor            = palette.highlight_high
-  selection         = palette.highlight_med
-  border            = palette.highlight_med
+  cursor            = palette.highlight.high
+  selection         = palette.highlight.mid
+  border            = palette.highlight.mid
   active_border     = palette.muted
   inactive_tab      = palette.surface
   active_tab        = palette.overlay


### PR DESCRIPTION
Add support for hierarchical palette definitions where colors can be organized in nested blocks. This enables syntax like:

```hcl
palette {
  base = #191724
  highlight {
    low  = #21202e
    mid  = #403d52
    high = #524f67
  }
}
```

Palette colors can now be referenced in HCL as `palette.highlight.low` and accessed in templates using simplified functions:

- `{{ palette highlight.low | hex }}` - returns `color.Color`
- `{{ style highlight.low }}` - returns `color.Style` with flags

Changes:
- `Palette` type changed from `map[string]Color` to `ColorTree`
- Added `parsePaletteBody()` for recursive palette parsing
- Updated `buildEvalContext()` to support nested cty objects
- Template functions now use closures to capture palette context
- Added `IsStyle()` helper for type checking
- Updated all tests and documentation