### PR TITLE
fix(lsp): prevent stale diagnostics and nil pointer errors in VS Code

### DIFF
--- a/internal/lsp/analyzer.go
+++ b/internal/lsp/analyzer.go
@@ -63,7 +63,8 @@ func hclRangeToLSP(r hcl.Range) protocol.Range {
 // and color locations. It collects ALL errors rather than short-circuiting on the first.
 func Analyze(filename, content string) *AnalysisResult {
 	result := &AnalysisResult{
-		Symbols: make(map[string]protocol.Range),
+		Symbols:     make(map[string]protocol.Range),
+		Diagnostics: []protocol.Diagnostic{}, // Initialize to empty slice, not nil
 	}
 
 	// Parse HCL from string content

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -1,0 +1,84 @@
+package lsp
+
+import (
+	"testing"
+)
+
+// TestDocumentStore_Update verifies that the document store properly updates content
+func TestDocumentStore_Update(t *testing.T) {
+	store := NewDocumentStore()
+
+	// Open a document
+	store.Open("test://file.pstheme", "initial content")
+
+	content, ok := store.Get("test://file.pstheme")
+	if !ok {
+		t.Fatal("Document not found after opening")
+	}
+	if content != "initial content" {
+		t.Errorf("Expected 'initial content', got '%s'", content)
+	}
+
+	// Update the document
+	store.Update("test://file.pstheme", "updated content")
+
+	content, ok = store.Get("test://file.pstheme")
+	if !ok {
+		t.Fatal("Document not found after update")
+	}
+	if content != "updated content" {
+		t.Errorf("Expected 'updated content', got '%s'", content)
+	}
+}
+
+// TestDocumentStore_MultipleUpdates verifies multiple updates work correctly
+func TestDocumentStore_MultipleUpdates(t *testing.T) {
+	store := NewDocumentStore()
+	store.Open("test://file.pstheme", "version 1")
+
+	updates := []string{
+		"version 2",
+		"version 3",
+		"version 4",
+	}
+
+	for i, update := range updates {
+		store.Update("test://file.pstheme", update)
+		content, ok := store.Get("test://file.pstheme")
+		if !ok {
+			t.Fatalf("Document not found after update %d", i+2)
+		}
+		if content != update {
+			t.Errorf("Update %d: expected '%s', got '%s'", i+2, update, content)
+		}
+	}
+}
+
+// TestDocumentStore_ConcurrentAccess verifies thread safety
+func TestDocumentStore_ConcurrentAccess(t *testing.T) {
+	store := NewDocumentStore()
+	store.Open("test://file.pstheme", "initial")
+
+	// Run concurrent updates
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(n int) {
+			store.Update("test://file.pstheme", string(rune('0'+n)))
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify document still exists and has some content
+	content, ok := store.Get("test://file.pstheme")
+	if !ok {
+		t.Error("Document not found after concurrent updates")
+	}
+	if content == "" {
+		t.Error("Document content is empty after concurrent updates")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes three related issues that caused problems when using the LSP through VS Code, as reported in #24.

## Problems Fixed

### 1. Race Condition with Rapid Edits
When typing rapidly (e.g., adding then removing a comma), the LSP would sometimes show stale diagnostics. This happened because:
- Analysis runs in a goroutine ()
- Multiple rapid changes could cause analyses to complete out of order
- Stale diagnostics would overwrite fresh results

**Solution**: Added document version tracking. Each change increments a version counter, and diagnostics are only published if the version hasn't changed since analysis started.

### 2. Unhandled Content Change Types
The LSP only handled  and silently ignored  (range-based changes). While the server declares Full document sync, VS Code can still send range-based changes in certain scenarios.

**Solution**: Handle both change types in .

### 3. Nil Diagnostics Causing TypeError
When no diagnostics were present, the  field remained , which serialized to  in JSON. VS Code's LSP client expects an empty array , causing:


**Solution**: Initialize  to an empty slice  instead of leaving it nil.

## Files Changed

- : Added version tracking and handled both change types
- : Initialize Diagnostics to empty slice
- : Added tests for DocumentStore

## Testing

All existing LSP tests pass. The fix has been verified to resolve the reported issue where:
1. Type 
2. Add a comma (syntax error appears)
3. Delete the comma
4. Error now correctly disappears immediately

Fixes #24