### PR TITLE
feat(lsp): add document formatting support

### DIFF
--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -1,0 +1,16 @@
+package lsp
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// format takes HCL source content and returns it formatted according to
+// HCL canonical style rules. It uses hclwrite.Format which handles
+// indentation, spacing, and newline normalization.
+//
+// The formatter works even on partial/invalid HCL, making it suitable
+// for use while the user is still typing.
+func format(content string) (string, error) {
+	formatted := hclwrite.Format([]byte(content))
+	return string(formatted), nil
+}

--- a/internal/lsp/format_test.go
+++ b/internal/lsp/format_test.go
@@ -1,0 +1,82 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic formatting",
+			input:    `meta{name="Test"author="Author"}`,
+			expected: `meta { name = "Test" author = "Author" }`,
+		},
+		{
+			name:     "palette with nested blocks",
+			input:    `palette{base="#191724"surface="#1f1d2e"highlight{low="#21202e"}}`,
+			expected: `palette { base = "#191724" surface = "#1f1d2e" highlight { low = "#21202e" } }`,
+		},
+		{
+			name: "already formatted stays same",
+			input: `meta {
+  name = "Test"
+}
+`,
+			expected: `meta {
+  name = "Test"
+}
+`,
+		},
+		{
+			name:     "extra whitespace normalized",
+			input:    `meta   {   name   =   "Test"   }`,
+			expected: `meta { name = "Test" }`,
+		},
+		{
+			name:     "empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name: "multiple blocks",
+			input: `meta{name="Test"}
+palette{base="#191724"}
+theme{background=palette.base}`,
+			expected: `meta { name = "Test" }
+palette { base = "#191724" }
+theme { background = palette.base }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := format(tt.input)
+			if err != nil {
+				t.Fatalf("format() error = %v", err)
+			}
+
+			// Normalize line endings for comparison
+			result = strings.TrimSuffix(result, "\n")
+			expected := strings.TrimSuffix(tt.expected, "\n")
+
+			if result != expected {
+				t.Errorf("format() = %q, want %q", result, expected)
+			}
+		})
+	}
+}
+
+func TestFormatInvalidHCL(t *testing.T) {
+	// hclwrite.Format should handle partial/invalid HCL gracefully
+	input := `meta { name = "Test"`
+	_, err := format(input)
+	// The function should not error even on incomplete HCL
+	if err != nil {
+		t.Errorf("format() on incomplete HCL should not error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Add textDocument/formatting support to pstheme-lsp for auto-formatting
.pstheme files. Uses hclwrite.Format() for canonical HCL formatting.

## Changes
- Add internal/lsp/format.go with core formatting logic using hclwrite.Format()
- Add TextDocumentFormatting handler to server.go
- Register DocumentFormattingProvider capability
- Add comprehensive tests for formatting functionality

## Features
- Formats .pstheme files on save when editor has formatOnSave enabled
- Uses HCL's canonical formatting rules for consistent style
- Works even on partial/invalid HCL (graceful degradation)
- Backward compatible - older LSP clients will simply not use the feature

Closes formatting feature request