### PR TITLE
chore: add GoReleaser configuration for cross-platform builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    goarm:
-      - "7"
 
 archives:
   - id: paletteswap


### PR DESCRIPTION
Adds GoReleaser config to build binaries for Linux, macOS, and Windows (amd64 and arm64).