### PR TITLE
ci: configure release-please for v0.x releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,6 +4,8 @@
       "release-type": "go",
       "package-name": "paletteswap",
       "draft": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         {"type":"feat","section":"Features","hidden":false},
         {"type":"fix","section":"Bug Fixes","hidden":false},


### PR DESCRIPTION
## Summary

Configure release-please to stay in v0.x versioning until ready for v1.0.0.

### Changes

Added two options to `.github/release-please-config.json`:

- **bump-minor-pre-major: true** - Breaking changes before v1.0.0 will bump the minor version (0.1.0 → 0.2.0) instead of major
- **bump-patch-for-minor-pre-major: true** - Features before v1.0.0 will bump the patch version (0.1.0 → 0.1.1) instead of minor

### Behavior

| Commit Type | Before | After this PR |
|-------------|--------|---------------|
| `feat:` | 0.1.0 → 0.2.0 | 0.1.0 → 0.1.1 |
| `fix:` | 0.1.0 → 0.1.1 | 0.1.0 → 0.1.1 (no change) |
| Breaking change | 0.1.0 → 1.0.0 | 0.1.0 → 0.2.0 |

This keeps the project in v0.x until you're explicitly ready to release v1.0.0.