### PR TITLE
ci: remove inline options from workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -87,22 +87,5 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: go
-          package-name: paletteswap
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
-          draft: true
-          changelog-types: |
-            [
-              {"type":"feat","section":"Features","hidden":false},
-              {"type":"fix","section":"Bug Fixes","hidden":false},
-              {"type":"docs","section":"Documentation","hidden":false},
-              {"type":"style","section":"Styles","hidden":true},
-              {"type":"refactor","section":"Code Refactoring","hidden":false},
-              {"type":"perf","section":"Performance Improvements","hidden":false},
-              {"type":"test","section":"Tests","hidden":true},
-              {"type":"build","section":"Build System","hidden":false},
-              {"type":"ci","section":"CI/CD","hidden":false},
-              {"type":"chore","section":"Chores","hidden":true},
-              {"type":"revert","section":"Reverts","hidden":false}
-            ]
+          config-file: .github/release-please-config.json
+          manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
## Summary

Fixes the warning about unexpected inputs in the release-please-action.

### Problem

The workflow had inline options that are not valid inputs for release-please-action@v4:
- `package-name`
- `bump-minor-pre-major`
- `bump-patch-for-minor-pre-major`
- `draft`
- `changelog-types`

These options should only be in the config file, not the workflow.

### Solution

Removed all inline options from the workflow and rely entirely on the config file (`.github/release-please-config.json`) which already has all these settings.

### Changes

Workflow now only passes:
- `token`
- `config-file`
- `manifest-file`

All other configuration is read from the config file.