### PR TITLE
fix(lsp): add DefinitionProvider capability for Zed compatibility

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -79,6 +79,7 @@ func (s *Server) initialize(_ *glsp.Context, params *protocol.InitializeParams) 
 		},
 	}
 	capabilities.DocumentFormattingProvider = true
+	capabilities.DefinitionProvider = true
 
 	return protocol.InitializeResult{
 		Capabilities: capabilities,


### PR DESCRIPTION
Add `capabilities.DefinitionProvider = true` to the LSP server initialization.
This enables "Go to definition" functionality in Zed and other editors that
strictly follow the LSP specification.

The server already had the definition handler implemented, but was missing the
capability advertisement required by the LSP spec. VS Code worked because it's
more lenient about missing capabilities, but Zed correctly requires explicit
advertisement.