### PR TITLE
ci: fix release workflow to handle release-please PRs

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,6 +63,10 @@ jobs:
           if echo "$COMBINED_TEXT" | grep -qE '^(feat|fix|perf|refactor|build|ci)(\(.+\))?:'; then
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "Found releasable commits"
+          # Also trigger for release-please PRs (they have "release" in the title)
+          elif echo "$PR_TITLE" | grep -qE '^chore\(main\): release'; then
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "Found release-please PR"
           else
             echo "should-release=false" >> "$GITHUB_OUTPUT"
             echo "No releasable commits found (only chore/docs/test/style)"


### PR DESCRIPTION
Update the release-pr workflow to also trigger when release-please PRs are merged.
Previously, the workflow only checked for conventional commit types (feat|fix|etc)
but release-please creates PRs with 'chore(main): release X.Y.Z' titles, which
were being skipped.

This fix adds a check for release-please PRs by detecting the pattern
'chore(main): release' in the PR title, ensuring releases are properly created
when release PRs are merged.