### PR TITLE
ci: add pstheme-lsp binary to release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,22 @@ builds:
       - amd64
       - arm64
 
+  - id: pstheme-lsp
+    main: ./cmd/pstheme-lsp
+    binary: pstheme-lsp
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: paletteswap
     name_template: >-


### PR DESCRIPTION
Add the pstheme-lsp binary to the GoReleaser configuration so both
binaries (paletteswap and pstheme-lsp) are shipped together in a single
archive per platform.