### PR TITLE
ci: add missing issues:write permission for release-please

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The release-please-action requires 'issues: write' permission in addition
to 'contents: write' and 'pull-requests: write' to function properly.