### PR TITLE
ci: exclude ci commits from triggering release-please

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -50,8 +50,8 @@ jobs:
           echo "Commit message:"
           echo "$COMMIT_MSG"
 
-          # Check for releasable commit types
-          if echo "$COMMIT_MSG" | grep -qE '^(feat|fix|perf|refactor|build|ci)(\(.+\))?:'; then
+          # Check for releasable commit types (excluding ci: since CI changes don't need releases)
+          if echo "$COMMIT_MSG" | grep -qE '^(feat|fix|perf|refactor|build)(\(.+\))?:'; then
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "Found releasable commits"
           # Also trigger for release-please PRs (they have "release" in the title)


### PR DESCRIPTION
Remove 'ci' from the list of commit types that trigger release-please.
CI changes are infrastructure-only and don't need releases.

This fixes the issue where merging CI-related PRs would cause
release-please to try creating releases for already-released PRs.