### PR TITLE
feat(lsp): collapse multiple blank lines when formatting

### DIFF
--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -1,8 +1,12 @@
 package lsp
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
+
+var multipleBlankLines = regexp.MustCompile(`\n{3,}`)
 
 // format takes HCL source content and returns it formatted according to
 // HCL canonical style rules. It uses hclwrite.Format which handles
@@ -12,5 +16,7 @@ import (
 // for use while the user is still typing.
 func format(content string) (string, error) {
 	formatted := hclwrite.Format([]byte(content))
-	return string(formatted), nil
+	// Collapse multiple consecutive blank lines into a single blank line.
+	collapsed := multipleBlankLines.ReplaceAllString(string(formatted), "\n\n")
+	return collapsed, nil
 }

--- a/internal/lsp/format_test.go
+++ b/internal/lsp/format_test.go
@@ -51,6 +51,21 @@ theme{background=palette.base}`,
 palette { base = "#191724" }
 theme { background = palette.base }`,
 		},
+		{
+			name: "multiple blank lines collapsed to one",
+			input: "meta { name = \"Test\" }\n\n\n\npalette { base = \"#191724\" }",
+			expected: "meta { name = \"Test\" }\n\npalette { base = \"#191724\" }",
+		},
+		{
+			name: "many blank lines collapsed to one",
+			input: "meta { name = \"Test\" }\n\n\n\n\n\n\npalette { base = \"#191724\" }",
+			expected: "meta { name = \"Test\" }\n\npalette { base = \"#191724\" }",
+		},
+		{
+			name: "single blank line preserved",
+			input: "meta { name = \"Test\" }\n\npalette { base = \"#191724\" }",
+			expected: "meta { name = \"Test\" }\n\npalette { base = \"#191724\" }",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- The LSP formatter now collapses multiple consecutive blank lines into a single blank line
- Adds a post-processing step after `hclwrite.Format` using a regex to normalize blank lines
- Adds three test cases covering multi-blank collapse, many-blank collapse, and single-blank preservation

## Test plan
- [x] All existing formatter tests pass
- [x] New test cases cover the blank line collapsing behavior
- [ ] Verify in editor that formatting a `.pstheme` file with multiple blank lines collapses them

🤖 Generated with [Claude Code](https://claude.com/claude-code)