### PR TITLE
feat(cli): add fmt subcommand for formatting .pstheme files

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-package lsp
+package format
 
 import (
 	"regexp"
@@ -8,13 +8,13 @@ import (
 
 var multipleBlankLines = regexp.MustCompile(`\n{3,}`)
 
-// format takes HCL source content and returns it formatted according to
+// Format takes HCL source content and returns it formatted according to
 // HCL canonical style rules. It uses hclwrite.Format which handles
 // indentation, spacing, and newline normalization.
 //
 // The formatter works even on partial/invalid HCL, making it suitable
 // for use while the user is still typing.
-func format(content string) (string, error) {
+func Format(content string) (string, error) {
 	formatted := hclwrite.Format([]byte(content))
 	// Collapse multiple consecutive blank lines into a single blank line.
 	collapsed := multipleBlankLines.ReplaceAllString(string(formatted), "\n\n")

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,4 +1,4 @@
-package lsp
+package format
 
 import (
 	"strings"
@@ -70,9 +70,9 @@ theme { background = palette.base }`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := format(tt.input)
+			result, err := Format(tt.input)
 			if err != nil {
-				t.Fatalf("format() error = %v", err)
+				t.Fatalf("Format() error = %v", err)
 			}
 
 			// Normalize line endings for comparison
@@ -80,7 +80,7 @@ theme { background = palette.base }`,
 			expected := strings.TrimSuffix(tt.expected, "\n")
 
 			if result != expected {
-				t.Errorf("format() = %q, want %q", result, expected)
+				t.Errorf("Format() = %q, want %q", result, expected)
 			}
 		})
 	}
@@ -89,9 +89,9 @@ theme { background = palette.base }`,
 func TestFormatInvalidHCL(t *testing.T) {
 	// hclwrite.Format should handle partial/invalid HCL gracefully
 	input := `meta { name = "Test"`
-	_, err := format(input)
+	_, err := Format(input)
 	// The function should not error even on incomplete HCL
 	if err != nil {
-		t.Errorf("format() on incomplete HCL should not error, got: %v", err)
+		t.Errorf("Format() on incomplete HCL should not error, got: %v", err)
 	}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/tliron/commonlog"
 	_ "github.com/tliron/commonlog/simple"
+
+	"github.com/jsvensson/paletteswap/internal/format"
 )
 
 const serverName = "pstheme-lsp"
@@ -196,7 +198,7 @@ func (s *Server) textDocumentFormatting(_ *glsp.Context, params *protocol.Docume
 		return nil, nil
 	}
 
-	formatted, err := format(content)
+	formatted, err := format.Format(content)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Extract format logic from `internal/lsp` into shared `internal/format` package so both the LSP and CLI use the same code
- Add `paletteswap fmt [files...]` command that formats `.pstheme` files in-place and prints modified filenames
- Add `-c`/`--check` flag for CI use — reports unformatted files and exits 1 without writing changes

## Test plan
- [ ] `go test ./internal/format/...` — format tests pass in new location
- [ ] `go test ./internal/lsp/...` — LSP tests still pass after import change
- [ ] `go test ./...` — full suite passes
- [ ] `paletteswap fmt theme.pstheme` formats a file with multiple blank lines
- [ ] `paletteswap fmt -c theme.pstheme` exits 1 for unformatted files, 0 for formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)