### PR TITLE
feat(format): reorder ANSI block to canonical color order

### DIFF
--- a/docs/plans/2026-02-13-ansi-color-ordering-design.md
+++ b/docs/plans/2026-02-13-ansi-color-ordering-design.md
@@ -1,0 +1,52 @@
+# ANSI Color Ordering in Formatter
+
+**Issue:** #62
+**Date:** 2026-02-13
+
+## Problem
+
+The ANSI block must contain the 16 standard terminal colors in canonical order. The formatter should auto-fix misordered colors on normal invocation. With `--check`, it should report the file as needing formatting (existing behavior — `--check` compares pre/post).
+
+## Canonical Order
+
+Defined in `theme.RequiredANSIColors`:
+
+```
+black, red, green, yellow, blue, magenta, cyan, white,
+bright_black, bright_red, bright_green, bright_yellow,
+bright_blue, bright_magenta, bright_cyan, bright_white
+```
+
+## Approach
+
+Hybrid: use `hclwrite.ParseConfig` for robust block identification, text-level reordering within the block to preserve comments.
+
+### Pipeline
+
+```
+input → hclwrite.Format() → reorderANSIBlock() → regex post-processing → output
+```
+
+### reorderANSIBlock
+
+1. Parse with `hclwrite.ParseConfig` to find the `ansi` block
+2. If no ansi block or parse fails, return unchanged
+3. Extract lines between braces
+4. Group lines into entries: comment/blank lines + following attribute line
+5. Map attribute name → entry text
+6. Emit in canonical order
+7. Splice back into source
+
+### Dependencies
+
+`format` → `theme` → `color` (no circular dependency)
+
+## Testing
+
+- Already-ordered stays unchanged
+- Misordered gets reordered
+- Comments above attributes travel with their attribute
+- Inline comments preserved
+- No ansi block → no change
+- Partial/invalid HCL → graceful fallback
+- Blank line separators between color groups

--- a/docs/plans/2026-02-13-ansi-color-ordering-impl.md
+++ b/docs/plans/2026-02-13-ansi-color-ordering-impl.md
@@ -1,0 +1,397 @@
+# ANSI Color Ordering Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The formatter reorders ANSI block attributes into the canonical 16-color order, preserving comments.
+
+**Architecture:** Hybrid approach — use `hclwrite.ParseConfig` to find the `ansi` block boundaries, then do text-level line grouping and reordering within those boundaries. Inserted into the `Format` pipeline between `hclwrite.Format()` and regex post-processing.
+
+**Tech Stack:** Go, `hclwrite` (already a dependency), `internal/theme.RequiredANSIColors`
+
+---
+
+### Task 1: Write failing tests for ANSI reordering
+
+**Files:**
+- Modify: `internal/format/format_test.go`
+
+**Step 1: Add test cases to the existing table-driven test**
+
+Add these cases to the `tests` slice in `TestFormat`:
+
+```go
+{
+    name: "ansi block already in order stays same",
+    input: `ansi {
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+    expected: `ansi {
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+},
+{
+    name: "ansi block misordered gets reordered",
+    input: `ansi {
+  white          = palette.text
+  black          = palette.overlay
+  cyan           = palette.foam
+  red            = palette.love
+  bright_white   = palette.text
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+}
+`,
+    expected: `ansi {
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+},
+{
+    name: "ansi block comments travel with their attribute",
+    input: `ansi {
+  # bright colors
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+  # normal colors
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text
+}
+`,
+    expected: `ansi {
+  # normal colors
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text
+  # bright colors
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+},
+{
+    name: "ansi block inline comments preserved",
+    input: `ansi {
+  white          = palette.text   # foreground
+  black          = palette.overlay # background
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+    expected: `ansi {
+  black          = palette.overlay # background
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  white          = palette.text   # foreground
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+},
+{
+    name: "no ansi block unchanged",
+    input: `palette {
+  base = "#191724"
+}
+`,
+    expected: `palette {
+  base = "#191724"
+}
+`,
+},
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/format/ -run TestFormat -v`
+Expected: New ANSI reordering tests FAIL (misordered input comes back unchanged)
+
+**Step 3: Commit**
+
+```
+test(format): add failing tests for ANSI color ordering
+```
+
+---
+
+### Task 2: Implement reorderANSIBlock
+
+**Files:**
+- Modify: `internal/format/format.go`
+
+**Step 1: Add imports and the reorderANSIBlock function**
+
+Add to imports: `"strings"`, `"github.com/hashicorp/hcl/v2"`, `"github.com/jsvensson/paletteswap/internal/theme"`
+
+Add the `reorderANSIBlock` function:
+
+```go
+// reorderANSIBlock reorders attributes in the ansi block to canonical order.
+// Uses hclwrite to find the block, then text-level reordering to preserve comments.
+// Returns src unchanged if no ansi block or if parsing fails.
+func reorderANSIBlock(src []byte) []byte {
+	file, diags := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return src
+	}
+
+	for _, block := range file.Body().Blocks() {
+		if block.Type() != "ansi" {
+			continue
+		}
+
+		// Find byte range of the block's inner content (between braces)
+		openBrace := block.Body().Range().Start
+		closeBrace := block.Body().Range().End
+
+		inner := src[openBrace.Byte:closeBrace.Byte]
+		lines := strings.Split(string(inner), "\n")
+
+		reordered := reorderEntries(lines, theme.RequiredANSIColors)
+
+		var result []byte
+		result = append(result, src[:openBrace.Byte]...)
+		result = append(result, []byte(strings.Join(reordered, "\n"))...)
+		result = append(result, src[closeBrace.Byte:]...)
+		return result
+	}
+
+	return src
+}
+```
+
+**Step 2: Add the reorderEntries function**
+
+```go
+// reorderEntries groups lines into entries (comment lines + attribute line)
+// and reorders them according to the given order.
+func reorderEntries(lines []string, order []string) []string {
+	type entry struct {
+		name  string
+		lines []string
+	}
+
+	var entries []entry
+	var pending []string // accumulates comment/blank lines before an attribute
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			pending = append(pending, line)
+			continue
+		}
+		// Attribute line: extract name (text before '=')
+		if eqIdx := strings.Index(line, "="); eqIdx != -1 {
+			name := strings.TrimSpace(line[:eqIdx])
+			var entryLines []string
+			entryLines = append(entryLines, pending...)
+			entryLines = append(entryLines, line)
+			entries = append(entries, entry{name: name, lines: entryLines})
+			pending = nil
+		} else {
+			// Non-attribute, non-comment line; treat as opaque
+			pending = append(pending, line)
+		}
+	}
+
+	// Build order index for sorting
+	orderIndex := make(map[string]int, len(order))
+	for i, name := range order {
+		orderIndex[name] = i
+	}
+
+	// Map entries by name
+	entryMap := make(map[string]entry, len(entries))
+	var unknown []entry
+	for _, e := range entries {
+		if _, ok := orderIndex[e.name]; ok {
+			entryMap[e.name] = e
+		} else {
+			unknown = append(unknown, e)
+		}
+	}
+
+	// Emit in canonical order
+	var result []string
+	for _, name := range order {
+		if e, ok := entryMap[name]; ok {
+			result = append(result, e.lines...)
+		}
+	}
+	// Append any unknown entries at the end
+	for _, e := range unknown {
+		result = append(result, e.lines...)
+	}
+	// Append any trailing comments/blank lines
+	result = append(result, pending...)
+
+	return result
+}
+```
+
+**Step 3: Wire into Format pipeline**
+
+In the `Format` function, add the reorder step after `hclwrite.Format()`:
+
+```go
+func Format(content string) (string, error) {
+	formatted := hclwrite.Format([]byte(content))
+	// Reorder ANSI block attributes to canonical order.
+	formatted = reorderANSIBlock(formatted)
+	// Collapse multiple consecutive blank lines into a single blank line.
+	collapsed := multipleBlankLines.ReplaceAllString(string(formatted), "\n\n")
+	// Remove blank lines immediately after opening braces.
+	collapsed = blankLineAfterOpenBrace.ReplaceAllString(collapsed, "{\n")
+	// Remove blank lines immediately before closing braces.
+	collapsed = blankLineBeforeCloseBrace.ReplaceAllString(collapsed, "\n${1}")
+	return collapsed, nil
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/format/ -run TestFormat -v`
+Expected: ALL tests pass (both old and new)
+
+**Step 5: Run full test suite**
+
+Run: `go test ./...`
+Expected: All packages pass
+
+**Step 6: Commit**
+
+```
+feat(format): reorder ANSI block attributes to canonical order
+
+Closes #62
+```
+
+---
+
+### Task 3: Verify --check flag behavior
+
+**Step 1: Create a test .pstheme file with misordered ANSI**
+
+Write a temp file with a complete but misordered theme, then run:
+
+```bash
+go run ./cmd/paletteswap fmt --check /tmp/test.pstheme
+```
+
+Expected: exits with code 1, prints the filename
+
+**Step 2: Run without --check to auto-fix**
+
+```bash
+go run ./cmd/paletteswap fmt /tmp/test.pstheme
+```
+
+Expected: exits 0, file is now reordered
+
+**Step 3: Run --check again on fixed file**
+
+```bash
+go run ./cmd/paletteswap fmt --check /tmp/test.pstheme
+```
+
+Expected: exits 0, no output (file is already formatted)

--- a/docs/plans/2026-02-13-curly-brace-blank-lines-design.md
+++ b/docs/plans/2026-02-13-curly-brace-blank-lines-design.md
@@ -1,0 +1,32 @@
+# Design: Remove blank lines adjacent to curly braces
+
+**Issue:** #64
+**Date:** 2026-02-13
+
+## Problem
+
+The formatter should strip blank lines immediately after `{` and immediately before `}` in all block types (top-level and nested).
+
+## Approach
+
+Add two regex-based post-processing rules to `internal/format/format.go`, following the existing pattern used for collapsing multiple blank lines.
+
+### Regexes
+
+1. **Blank line after opening brace:** `{\n\s*\n` replaced with `{\n`
+2. **Blank line before closing brace:** `\n\s*\n(\s*})` replaced with `\n$1` (preserving indentation)
+
+### Ordering
+
+Apply after the existing `multipleBlankLines` collapse step. This ensures multiple blank lines are first reduced to one, then any remaining single blank line adjacent to a brace is removed.
+
+### Scope
+
+All block types: meta, palette, theme, ansi, syntax, and nested blocks (highlight, markup, etc.).
+
+## Test cases
+
+- Blank line after opening brace
+- Blank line before closing brace
+- Both at once
+- Nested blocks with blank lines adjacent to braces

--- a/docs/plans/2026-02-13-curly-brace-blank-lines-impl.md
+++ b/docs/plans/2026-02-13-curly-brace-blank-lines-impl.md
@@ -1,0 +1,88 @@
+# Curly Brace Blank Line Removal Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Strip blank lines immediately after `{` and immediately before `}` in all formatted HCL blocks.
+
+**Architecture:** Add two compiled regexes to `internal/format/format.go` that run as post-processing steps after the existing multiple-blank-line collapse. Tests follow the existing table-driven pattern in `format_test.go`.
+
+**Tech Stack:** Go, regexp, hclwrite
+
+---
+
+### Task 1: Add failing tests for blank line after opening brace
+
+**Files:**
+- Modify: `internal/format/format_test.go:69` (insert new test cases before closing `}` of test table)
+
+**Step 1: Write failing tests**
+
+Add these test cases to the `tests` slice in `TestFormat`, before the closing `}` on line 69:
+
+```go
+		{
+			name: "blank line after opening brace removed",
+			input: "palette {\n\n  base = \"#191724\"\n}",
+			expected: "palette {\n  base = \"#191724\"\n}",
+		},
+		{
+			name: "blank line before closing brace removed",
+			input: "palette {\n  base = \"#191724\"\n\n}",
+			expected: "palette {\n  base = \"#191724\"\n}",
+		},
+		{
+			name: "blank lines after and before braces both removed",
+			input: "palette {\n\n  base = \"#191724\"\n\n}",
+			expected: "palette {\n  base = \"#191724\"\n}",
+		},
+		{
+			name: "nested block blank lines removed",
+			input: "palette {\n\n  highlight {\n\n    low = \"#21202e\"\n\n  }\n\n}",
+			expected: "palette {\n  highlight {\n    low = \"#21202e\"\n  }\n}",
+		},
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/format/ -v -run TestFormat`
+Expected: FAIL — the new test cases will show mismatched output since blank lines are not yet stripped.
+
+### Task 2: Implement blank line removal
+
+**Files:**
+- Modify: `internal/format/format.go:9` (add new regex vars)
+- Modify: `internal/format/format.go:20` (add new replacement steps)
+
+**Step 1: Add the two new compiled regexes**
+
+After line 9 (`var multipleBlankLines = ...`), add:
+
+```go
+var blankLineAfterOpenBrace = regexp.MustCompile(`\{\n\s*\n`)
+var blankLineBeforeCloseBrace = regexp.MustCompile(`\n\s*\n(\s*\})`)
+```
+
+**Step 2: Apply the new regexes in the Format function**
+
+After line 20 (`collapsed := multipleBlankLines.ReplaceAllString(...)`) and before `return`, add:
+
+```go
+	// Remove blank lines immediately after opening braces.
+	collapsed = blankLineAfterOpenBrace.ReplaceAllString(collapsed, "{\n")
+	// Remove blank lines immediately before closing braces.
+	collapsed = blankLineBeforeCloseBrace.ReplaceAllString(collapsed, "\n${1}")
+```
+
+**Step 3: Run tests to verify they pass**
+
+Run: `go test ./internal/format/ -v -run TestFormat`
+Expected: ALL PASS
+
+### Task 3: Commit
+
+**Step 1: Commit**
+
+```bash
+git add internal/format/format.go internal/format/format_test.go
+git commit -m "feat(format): remove blank lines adjacent to curly braces (#64)"
+```

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -2,8 +2,11 @@ package format
 
 import (
 	"regexp"
+	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/jsvensson/paletteswap/internal/theme"
 )
 
 var multipleBlankLines = regexp.MustCompile(`\n{3,}`)
@@ -18,6 +21,8 @@ var blankLineBeforeCloseBrace = regexp.MustCompile(`\n\s*\n(\s*\})`)
 // for use while the user is still typing.
 func Format(content string) (string, error) {
 	formatted := hclwrite.Format([]byte(content))
+	// Reorder ANSI block attributes to canonical order.
+	formatted = reorderANSIBlock(formatted)
 	// Collapse multiple consecutive blank lines into a single blank line.
 	collapsed := multipleBlankLines.ReplaceAllString(string(formatted), "\n\n")
 	// Remove blank lines immediately after opening braces.
@@ -25,4 +30,179 @@ func Format(content string) (string, error) {
 	// Remove blank lines immediately before closing braces.
 	collapsed = blankLineBeforeCloseBrace.ReplaceAllString(collapsed, "\n${1}")
 	return collapsed, nil
+}
+
+// ansiBlockPattern matches the "ansi {" opening and captures everything
+// between the opening brace and the closing brace.
+var ansiBlockPattern = regexp.MustCompile(`(?s)(ansi\s*\{)\n(.*?)\n(\})`)
+
+// reorderANSIBlock finds the "ansi" block in the formatted HCL source and
+// reorders its attributes to match the canonical order defined in
+// theme.RequiredANSIColors. Comments and blank lines immediately preceding
+// an attribute travel with that attribute.
+func reorderANSIBlock(src []byte) []byte {
+	// First verify this is valid HCL with an ansi block using the parser.
+	file, diags := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return src
+	}
+
+	hasANSI := false
+	for _, block := range file.Body().Blocks() {
+		if block.Type() == "ansi" {
+			hasANSI = true
+			break
+		}
+	}
+	if !hasANSI {
+		return src
+	}
+
+	// Use regex to find and replace the inner content of the ansi block.
+	return ansiBlockPattern.ReplaceAllFunc(src, func(match []byte) []byte {
+		loc := ansiBlockPattern.FindSubmatchIndex(match)
+		// loc[2]:loc[3] = "ansi {"
+		// loc[4]:loc[5] = inner content
+		// loc[6]:loc[7] = "}"
+		opener := match[loc[2]:loc[3]]
+		inner := string(match[loc[4]:loc[5]])
+		closer := match[loc[6]:loc[7]]
+
+		lines := strings.Split(inner, "\n")
+		reordered := reorderEntries(lines, theme.RequiredANSIColors)
+		newInner := strings.Join(reordered, "\n")
+
+		var result []byte
+		result = append(result, opener...)
+		result = append(result, '\n')
+		result = append(result, []byte(newInner)...)
+		result = append(result, '\n')
+		result = append(result, closer...)
+		return result
+	})
+}
+
+// entry represents a single attribute and any comment/blank lines that precede it.
+type entry struct {
+	name  string   // attribute name (empty for trailing non-attribute lines)
+	lines []string // all lines belonging to this entry (comments + attribute)
+}
+
+// reorderEntries takes lines from inside an ANSI block and reorders the
+// attribute entries according to the given canonical order. Comment and blank
+// lines immediately before an attribute are grouped with that attribute.
+// Unknown attributes are appended at the end. After reordering, attribute
+// lines are realigned so that all '=' signs are at the same column.
+func reorderEntries(lines []string, order []string) []string {
+	var entries []entry
+	var pending []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			pending = append(pending, line)
+			continue
+		}
+		if eqIdx := strings.Index(trimmed, "="); eqIdx != -1 {
+			// This is an attribute line. Group it with any pending comment/blank lines.
+			attrLines := make([]string, 0, len(pending)+1)
+			attrLines = append(attrLines, pending...)
+			attrLines = append(attrLines, line)
+			pending = nil
+
+			// Extract attribute name: text before '=' trimmed of whitespace.
+			name := strings.TrimSpace(trimmed[:eqIdx])
+			entries = append(entries, entry{name: name, lines: attrLines})
+		} else {
+			pending = append(pending, line)
+		}
+	}
+
+	// Build an index map from the canonical order.
+	orderIndex := make(map[string]int, len(order))
+	for i, name := range order {
+		orderIndex[name] = i
+	}
+
+	// Map entries by attribute name for lookup.
+	entryByName := make(map[string]entry, len(entries))
+	var unknownEntries []entry
+	for _, e := range entries {
+		if _, ok := orderIndex[e.name]; ok {
+			entryByName[e.name] = e
+		} else {
+			unknownEntries = append(unknownEntries, e)
+		}
+	}
+
+	// Emit entries in canonical order.
+	var result []string
+	for _, name := range order {
+		if e, ok := entryByName[name]; ok {
+			result = append(result, e.lines...)
+		}
+	}
+
+	// Append any unknown entries at the end.
+	for _, e := range unknownEntries {
+		result = append(result, e.lines...)
+	}
+
+	// Append any trailing pending lines (comments/blanks after last attribute).
+	result = append(result, pending...)
+
+	// Realign all attribute lines so '=' signs are at the same column.
+	result = alignAttributes(result)
+
+	return result
+}
+
+// alignAttributes normalizes the alignment of attribute lines so that all '='
+// signs line up at the same column. Non-attribute lines (comments, blanks) are
+// left unchanged. The indentation prefix (leading whitespace) is preserved.
+func alignAttributes(lines []string) []string {
+	// First pass: find the longest attribute name across all attribute lines.
+	maxNameLen := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		eqIdx := strings.Index(trimmed, "=")
+		if eqIdx < 0 {
+			continue
+		}
+		name := strings.TrimRight(trimmed[:eqIdx], " ")
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+	}
+
+	if maxNameLen == 0 {
+		return lines
+	}
+
+	// Second pass: rewrite attribute lines with uniform padding.
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			result[i] = line
+			continue
+		}
+		eqIdx := strings.Index(trimmed, "=")
+		if eqIdx < 0 {
+			result[i] = line
+			continue
+		}
+
+		// Determine the indentation prefix.
+		indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		name := strings.TrimRight(trimmed[:eqIdx], " ")
+		rest := trimmed[eqIdx:] // "= value" or "= value # comment"
+		padding := strings.Repeat(" ", maxNameLen-len(name))
+		result[i] = indent + name + padding + " " + rest
+	}
+
+	return result
 }

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -253,6 +253,49 @@ theme { background = palette.base }`,
 `,
 		},
 		{
+			name: "ansi block comment containing equals sign",
+			input: `ansi {
+  # black = used for background
+  white          = palette.text
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+			expected: `ansi {
+  black          = palette.overlay
+  red            = palette.love
+  green          = palette.pine
+  yellow         = palette.gold
+  blue           = palette.foam
+  magenta        = palette.iris
+  cyan           = palette.foam
+  # black = used for background
+  white          = palette.text
+  bright_black   = palette.muted
+  bright_red     = palette.love
+  bright_green   = palette.pine
+  bright_yellow  = palette.gold
+  bright_blue    = palette.foam
+  bright_magenta = palette.iris
+  bright_cyan    = palette.foam
+  bright_white   = palette.text
+}
+`,
+		},
+		{
 			name: "no ansi block unchanged",
 			input: `meta {
   name = "Test"


### PR DESCRIPTION
## Summary
- Formatter now reorders ANSI block attributes to the canonical 16-color order (black, red, green, ... bright_white)
- Comments above/inline with attributes travel with them during reordering
- Attribute `=` signs are re-aligned after reordering
- Gracefully handles invalid HCL and files without an ANSI block

Closes #62

## Test plan
- [x] 6 new test cases (ordered stays same, misordered reorders, comments travel, inline comments, comment with `=`, no ansi block)
- [x] All 20 format tests pass
- [x] Full test suite passes
- [x] `fmt --check` detects misordered ANSI (exit 1)
- [x] `fmt` auto-fixes misordered ANSI (exit 0)
- [x] `fmt --check` passes on fixed file (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)