### PR TITLE
fix(lsp): exclude reserved 'color' keyword from palette completions

### DIFF
--- a/internal/lsp/analyzer.go
+++ b/internal/lsp/analyzer.go
@@ -616,11 +616,16 @@ func (r *AnalysisResult) processBlockAttribute(attr *hclsyntax.Attribute,
 	ctx.Symbols[symbolName] = hclRangeToLSP(attr.SrcRange)
 	r.Symbols[symbolName] = hclRangeToLSP(attr.SrcRange)
 
-	// Update node tree
-	if ctx.Node.Children == nil {
-		ctx.Node.Children = make(map[string]*color.Node)
+	// Update node tree — "color" is a reserved keyword that sets the node's
+	// own color rather than creating a child entry.
+	if attr.Name == "color" && ctx.BlockType.SupportsNesting {
+		ctx.Node.Color = &c
+	} else {
+		if ctx.Node.Children == nil {
+			ctx.Node.Children = make(map[string]*color.Node)
+		}
+		ctx.Node.Children[attr.Name] = &color.Node{Color: &c}
 	}
-	ctx.Node.Children[attr.Name] = &color.Node{Color: &c}
 
 	resolved[attr.Name] = true
 }

--- a/internal/lsp/completion_test.go
+++ b/internal/lsp/completion_test.go
@@ -272,14 +272,21 @@ ansi {
 	}
 
 	// Should include highlight children: low, high
-	// "color" is the node's own color, not a child to complete as "palette.highlight.color"
-	// but it IS stored as a key; the implementation may or may not include it.
-	// We definitely expect low and high.
 	if !hasLabel(items, "low") {
 		t.Error("expected completion item 'low'")
 	}
 	if !hasLabel(items, "high") {
 		t.Error("expected completion item 'high'")
+	}
+
+	// "color" is a reserved keyword — it must NOT be suggested as a completion
+	if hasLabel(items, "color") {
+		t.Error("should not suggest reserved keyword 'color' as palette completion")
+	}
+
+	// Exactly two items expected: low, high
+	if len(items) != 2 {
+		t.Errorf("expected exactly 2 completion items, got %d: %v", len(items), completionLabels(items))
 	}
 }
 
@@ -700,5 +707,10 @@ ansi {
 	}
 	if !hasLabel(items, "high") {
 		t.Error("expected completion item 'high' for palette.highlight.")
+	}
+
+	// "color" is a reserved keyword — it must NOT be suggested
+	if hasLabel(items, "color") {
+		t.Error("should not suggest reserved keyword 'color' as palette completion")
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `processBlockAttribute` to store `color` on `node.Color` instead of `node.Children` for nesting-capable blocks (palette), matching parser behavior
- Prevents the completer from suggesting `palette.foo.color` as an autocomplete option
- Adds explicit test assertions that `color` must not appear in nested palette completions

Closes #67

## Test plan
- [x] `TestCompletion_PaletteNested` asserts `color` is excluded and exactly 2 items returned
- [x] `TestCompletion_PaletteNestedWithSyntaxError` asserts `color` is excluded
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)