### PR TITLE
ci: dispatch GoReleaser from release-please workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,6 +17,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -67,6 +68,9 @@ jobs:
     needs: check-releasable
     runs-on: ubuntu-latest
     if: needs.check-releasable.outputs.should-release == 'true'
+    outputs:
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,8 +83,19 @@ jobs:
           node-version: '20'
 
       - name: Create Release PR
+        id: release-please
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+
+  trigger-goreleaser:
+    needs: release-pr
+    runs-on: ubuntu-latest
+    if: needs.release-pr.outputs.release_created == 'true'
+    steps:
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml -R ${{ github.repository }} -f tag=${{ needs.release-pr.outputs.tag_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,5 +72,6 @@ release:
   github:
     owner: jsvensson
     name: paletteswap
+  mode: append
   draft: false
   prerelease: auto


### PR DESCRIPTION
## Summary
- Add `trigger-goreleaser` job to `release-pr.yml` that dispatches the release workflow via `workflow_dispatch` when release-please creates a release
- Set GoReleaser `mode: append` so it adds binaries to the existing release instead of creating a new one
- Fixes missing binaries on releases v0.1.3–v0.1.6 caused by `GITHUB_TOKEN` tag pushes not triggering workflows

## Test plan
- [x] Manually triggered `release.yml` for v0.1.6 to verify GoReleaser works with `mode: append`
- [ ] Verify next release-please merge triggers GoReleaser automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)